### PR TITLE
Add --ignore Flag to Skip Selected Smell Checks #4

### DIFF
--- a/goblin/analyzer.py
+++ b/goblin/analyzer.py
@@ -8,7 +8,7 @@ from goblin.smell_types import SmellType
 
 
 @dataclass
-class TestMethod:
+class MethodInfo:
     class_name: str
     method_name: str
     annotations: List[str]
@@ -16,11 +16,11 @@ class TestMethod:
     smells: List[SmellType] = field(default_factory=list)
 
 @dataclass
-class TestClass:
+class ClassInfo:
     class_name: str
-    methods: List[TestMethod]
+    methods: List[MethodInfo]
 
-def parse_java_file(file_path: str) -> TestClass:
+def parse_java_file(file_path: str) -> ClassInfo:
     with open(file_path, 'r') as file:
         source_code = file.read()
 
@@ -47,7 +47,7 @@ def parse_java_file(file_path: str) -> TestClass:
                "assert" in statement.expression.member.lower()
         )
 
-        test_method = TestMethod(
+        test_method = MethodInfo(
             class_name=class_declaration.name,
             method_name=method_name,
             annotations=annotations,
@@ -56,7 +56,7 @@ def parse_java_file(file_path: str) -> TestClass:
         test_method.smells = detect_smells(test_method)
         test_methods.append(test_method)
 
-    return TestClass(
+    return ClassInfo(
         class_name=class_declaration.name,
         methods=test_methods
     )

--- a/goblin/detector.py
+++ b/goblin/detector.py
@@ -16,11 +16,11 @@ def smell_todo_annotation(method):
 
 def smell_disabled(method):
     if "DISABLED" in [a.upper() for a in method.annotations]:
-        return SmellType.DISABLED
+        return SmellType.DISABLED_ANNOTATION
     
 def smell_ignored(method):
     if "IGNORE" in [a.upper() for a in method.annotations]:
-        return SmellType.IGNORED
+        return SmellType.IGNORE_ANNOTATION
 
 def smell_no_annotation(method):
     if (("TEST" in method.method_name.upper()) or method.assertion_count != 0) and ("TEST" not in [a.upper() for a in method.annotations]):

--- a/goblin/smell_types.py
+++ b/goblin/smell_types.py
@@ -2,8 +2,14 @@ from enum import Enum
 
 
 class SmellType(str, Enum):
-    NO_ASSERTIONS = "no-assertions"
-    TODO_ANNOTATION = "todo-annotation"
-    DISABLED = "disabled-annotation"
-    IGNORED = "ignore-annotation"
-    MISSING_TEST_ANNOTATION = "missing-test-annotation"
+    NO_ASSERTIONS = "No assertions found in test method"
+    TODO_ANNOTATION = "Unresolved TODO annotation"
+    DISABLED_ANNOTATION = "Disabled test annotation, consider cleaning up"
+    IGNORE_ANNOTATION = "Ignore annotation, consider cleaning up"
+    MISSING_TEST_ANNOTATION = "Missing @Test annotation in test-like method"
+
+    @classmethod
+    def print_available_smell_types(cls):
+        print("Available smell types:")
+        for smell in cls:
+            print(f"- {smell.value}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [tool.ruff]
 line-length = 100
-target-version = py39
+target-version = "py39"
 # "E" for error codes, "F" for formatting issues, "I" for import-related issues
 select = ["E", "F", "I"]
 name = "goblin-cli"
-name = "unit-test-goblin"
 version = "0.1.0"
 description = "A CLI tool for automating and managing Python unit tests with enhanced reporting and debugging features (development version)"
 authors = ["gpapachr"]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -6,7 +6,7 @@ def test_parse_example_test_file():
     test_class = parse_java_file(file_path)
 
     assert test_class.class_name == "ExampleTest"
-    assert len(test_class.methods) == 2
+    assert len(test_class.methods) == 8
 
     test_method = test_class.methods[0]
     assert test_method.method_name == "testAddition"

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,13 +1,13 @@
 import pytest
 from goblin.detector import detect_smells
 from goblin.smell_types import SmellType
-from goblin.analyzer import TestMethod
+from goblin.analyzer import MethodInfo
 
 CLASS_NAME = "TestClass"
 METHOD_NAME = "testMethod"
 
 def test_no_assertions_smell():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["Test"],
@@ -17,7 +17,7 @@ def test_no_assertions_smell():
     assert SmellType.NO_ASSERTIONS in smells
 
 def test_todo_annotation_smell():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["TODO"],
@@ -27,27 +27,27 @@ def test_todo_annotation_smell():
     assert SmellType.TODO_ANNOTATION in smells
 
 def test_disabled_annotation_smell():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["Disabled"],
         assertion_count=1
     )
     smells = detect_smells(method)
-    assert SmellType.DISABLED in smells
+    assert SmellType.DISABLED_ANNOTATION in smells
 
 def test_ignored_annotation_smell():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["Ignore"],
         assertion_count=1
     )
     smells = detect_smells(method)
-    assert SmellType.IGNORED in smells
+    assert SmellType.IGNORE_ANNOTATION in smells
 
 def test_missing_test_annotation_smell():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=[],
@@ -57,7 +57,7 @@ def test_missing_test_annotation_smell():
     assert SmellType.MISSING_TEST_ANNOTATION in smells
 
 def test_multiple_smells():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["TODO", "Disabled", "Test"],
@@ -66,10 +66,10 @@ def test_multiple_smells():
     smells = detect_smells(method)
     assert SmellType.NO_ASSERTIONS in smells
     assert SmellType.TODO_ANNOTATION in smells
-    assert SmellType.DISABLED in smells
+    assert SmellType.DISABLED_ANNOTATION in smells
 
 def test_no_smells():
-    method = TestMethod(
+    method = MethodInfo(
         class_name=CLASS_NAME,
         method_name=METHOD_NAME,
         annotations=["Test"],


### PR DESCRIPTION
This PR implements support for the --ignore flag in the CLI, allowing users to selectively disable specific test smell checks.

What’s New
- CLI flag `--ignore` now accepts space-separated smell types (e.g., `--ignore no-assertions todo-annotation`)
- Smells specified in `--ignore` are skipped during analysis
- Smells ignored are neither printed nor included in the summary stats
- Input validation ensures only supported smell types are accepted
- Updated help text and usage examples

Also
- Added descriptive messages in smell types instead of plain values
- Added `print_available_smell_types()` in smell types class. For now is used in help message for `--ignore` arguments but may be useful for future use too. 

Tests
- Adjusted unit tests to reflect changes
- Rename naming conventions in analyzer for our objects to avoid warnings dyring test running due to `Test*` usage in previous names

Closes #4 